### PR TITLE
changing the 30 second break to 60 seconds

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/HearingRecordingSegmentScenarios.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/HearingRecordingSegmentScenarios.java
@@ -41,7 +41,7 @@ public class HearingRecordingSegmentScenarios extends BaseTest {
             .log().all()
             .statusCode(202);
 
-        TimeUnit.SECONDS.sleep(30);
+        TimeUnit.SECONDS.sleep(60);
 
         getFilenames(FOLDER)
             .assertThat().log().all()


### PR DESCRIPTION



### Change description ###

Changing the 30 second break between creating a blob and looking for a blob in the functional tests to 60 seconds 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
