### PR TITLE
adding a functional test for sharing with caseworker-hrs

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
@@ -68,7 +68,7 @@ public abstract class BaseTest {
     protected static final String BEARER = "Bearer ";
     protected static final String FILE_EXT = "mp4";
     protected static final String SHAREE_EMAIL_ADDRESS = "sharee@email.com";
-    protected static final String CASEWORKER_HRS_USER = "caseworker.hrs.user@email.com";
+    protected static final String CASEWORKER_HRS_USER = "em.hrs.api@hmcts.net.internal";
     protected static final String CASEWORKER_USER = "hearing.audio.requester@gmail.com";
     protected static final String CITIZEN_USER = "citizen.role@outlook.com";
     protected static final String ERROR_SHAREE_EMAIL_ADDRESS = "sharee.testertest.com";

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/ShareHearingRecordingScenarios.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/ShareHearingRecordingScenarios.java
@@ -69,7 +69,7 @@ public class ShareHearingRecordingScenarios extends BaseTest {
 
     @Test
     public void shareeWithCaseworkerHrsRoleShouldBeAbleToDownloadRecordings() {
-        final CallbackRequest callbackRequest = createCallbackRequest(caseDetails, CASEWORKER_USER);
+        final CallbackRequest callbackRequest = createCallbackRequest(caseDetails, CASEWORKER_HRS_USER);
         shareRecording(CASEWORKER_HRS_USER, CASE_WORKER_HRS_ROLE, callbackRequest)
             .then()
             .log().all()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/ShareHearingRecordingScenarios.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/ShareHearingRecordingScenarios.java
@@ -68,6 +68,26 @@ public class ShareHearingRecordingScenarios extends BaseTest {
     }
 
     @Test
+    public void shareeWithCaseworkerHrsRoleShouldBeAbleToDownloadRecordings() {
+        final CallbackRequest callbackRequest = createCallbackRequest(caseDetails, CASEWORKER_USER);
+        shareRecording(CASEWORKER_HRS_USER, CASE_WORKER_HRS_ROLE, callbackRequest)
+            .then()
+            .log().all()
+            .assertThat()
+            .statusCode(200);
+
+        final byte[] downloadedFileBytes =
+            downloadRecording(CASEWORKER_HRS_USER, CASE_WORKER_HRS_ROLE, caseDetails.getData())
+                .then()
+                .statusCode(200)
+                .extract().response()
+                .body().asByteArray();
+
+        final int actualFileSize = downloadedFileBytes.length;
+        assertThat(actualFileSize, is(expectedFileSize));
+    }
+
+    @Test
     public void shareeWithCaseworkerRoleShouldBeAbleToDownloadRecordings() {
         final CallbackRequest callbackRequest = createCallbackRequest(caseDetails, CASEWORKER_USER);
         shareRecording(CASEWORKER_USER, CASE_WORKER_ROLE, callbackRequest)
@@ -77,7 +97,7 @@ public class ShareHearingRecordingScenarios extends BaseTest {
             .statusCode(200);
 
         final byte[] downloadedFileBytes =
-            downloadRecording(CASEWORKER_USER, CITIZEN_ROLE, caseDetails.getData())
+            downloadRecording(CASEWORKER_USER, CASE_WORKER_ROLE, caseDetails.getData())
                 .then()
                 .statusCode(200)
                 .extract().response()


### PR DESCRIPTION

### Change description ###
adding a functional test for the scenario where a recording is shared with a user with caseworker-hrs role


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
