### PR TITLE
add test to ensure malformed filenames are not copied

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/HearingRecordingSegmentScenarios.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/HearingRecordingSegmentScenarios.java
@@ -70,7 +70,7 @@ public class HearingRecordingSegmentScenarios extends BaseTest {
     }
 
     @Test
-    public void shouldNotCreateHearingRecordingSegmentWhenFileNameMalformed() throws Exception {
+    public void shouldNotCopyHearingRecordingSegmentWhenFileNameMalformed() throws Exception {
         caseRef = "I'm malformed now " + caseRef + " I'm malformed now";
         postRecordingSegment(caseRef)
             .then()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/HearingRecordingSegmentScenarios.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/HearingRecordingSegmentScenarios.java
@@ -84,7 +84,7 @@ public class HearingRecordingSegmentScenarios extends BaseTest {
             .statusCode(200)
             .body("folder-name", equalTo(FOLDER))
             .body("filenames", hasSize(0))
-            .body("filenames", contains(""));
+            .body("filenames", contains());
     }
 
     @Test

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/HearingRecordingSegmentScenarios.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/HearingRecordingSegmentScenarios.java
@@ -70,6 +70,24 @@ public class HearingRecordingSegmentScenarios extends BaseTest {
     }
 
     @Test
+    public void shouldNotCreateHearingRecordingSegmentWhenFileNameMalformed() throws Exception {
+        caseRef = caseRef + "I'm malformed now";
+        postRecordingSegment(caseRef)
+            .then()
+            .log().all()
+            .statusCode(202);
+
+        TimeUnit.SECONDS.sleep(30);
+
+        getFilenames(FOLDER)
+            .assertThat().log().all()
+            .statusCode(200)
+            .body("folder-name", equalTo(FOLDER))
+            .body("filenames", hasSize(0))
+            .body("filenames", contains(""));
+    }
+
+    @Test
     public void shouldCreateFolderWhenDoesNotExistAndReturnEmptyFileNames() {
         final String nonExistentFolder = "audiostream000000";
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/HearingRecordingSegmentScenarios.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/HearingRecordingSegmentScenarios.java
@@ -71,7 +71,7 @@ public class HearingRecordingSegmentScenarios extends BaseTest {
 
     @Test
     public void shouldNotCreateHearingRecordingSegmentWhenFileNameMalformed() throws Exception {
-        caseRef = caseRef + "I'm malformed now";
+        caseRef = "I'm malformed now " + caseRef + " I'm malformed now";
         postRecordingSegment(caseRef)
             .then()
             .log().all()
@@ -83,8 +83,7 @@ public class HearingRecordingSegmentScenarios extends BaseTest {
             .assertThat().log().all()
             .statusCode(200)
             .body("folder-name", equalTo(FOLDER))
-            .body("filenames", hasSize(0))
-            .body("filenames", contains());
+            .body("filenames", empty());
     }
 
     @Test


### PR DESCRIPTION

### Change description ###

Adding a functional test to cover the scenario where a hearing recording with a malformed file-name should not be copied 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
