### PR TITLE
fix azure ad to 1.6

### DIFF
--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -2,6 +2,12 @@ terraform {
   backend "azurerm" {}
 
   required_providers {
+
+        azuread = {
+          source  = "hashicorp/azuread"
+          version = "1.6.0"
+        }
+
         azurerm = {
           source  = "hashicorp/azurerm"
           version = "~> 2.35"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-4024


### Change description ###
terraform - fix azure ad to 1.6



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
