### PR TITLE
guard against users being deleted by seperate PR branches and fix email addresses

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
@@ -70,9 +70,9 @@ public abstract class BaseTest {
     protected static final String CASE_TYPE = "HearingRecordings";
     protected static final String BEARER = "Bearer ";
     protected static final String FILE_EXT = "mp4";
-    protected static final String USER_WITH_SEARCHER_ROLE__CASEWORKER_HRS = "em-test-caseworker-hrs@hmcts.net";
-    protected static final String USER_WITH_REQUESTOR_ROLE__CASEWORKER = "em-test-caseworker@hmcts.net";
-    protected static final String USER_WITH_NONACCESS_ROLE__CITIZEN = "em-test-citizen@hmcts.net";
+    protected static final String USER_WITH_SEARCHER_ROLE__CASEWORKER_HRS = "em-test-caseworker-hrs@test.internal";
+    protected static final String USER_WITH_REQUESTOR_ROLE__CASEWORKER = "em-test-caseworker@test.internal";
+    protected static final String USER_WITH_NONACCESS_ROLE__CITIZEN = "em-test-citizen@test.internal";
     protected static final String EMAIL_ADDRESS_INVALID_FORMAT = "invalid@emailaddress";
     protected static final String FOLDER = "audiostream123455";
     protected static final String TIME = "2020-11-04-14.56.32.819";

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
@@ -48,7 +48,6 @@ import javax.annotation.PostConstruct;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static uk.gov.hmcts.reform.em.hrs.testutil.ExtendedCcdHelper.HRS_TESTER;
 
 @SpringBootTest(classes = {
     ExtendedCcdHelper.class,
@@ -84,6 +83,9 @@ public abstract class BaseTest {
     protected static List<String> CITIZEN_ROLE = List.of("citizen");
     protected static final String CLOSE_CASE = "closeCase";
 
+    public static String HRS_TESTER = "hrs.test.user@hmcts.net";
+    public static List<String> HRS_TESTER_ROLES = List.of("caseworker", "caseworker-hrs", "ccd-import");
+
     int FIND_CASE_TIMEOUT = 30;
 
     protected String idamAuth_hrs_tester;
@@ -116,21 +118,45 @@ public abstract class BaseTest {
     @Autowired
     protected CoreCaseDataApi coreCaseDataApi;
 
+
     @Autowired
     protected ExtendedCcdHelper extendedCcdHelper;
 
     @PostConstruct
     public void init() {
         SerenityRest.useRelaxedHTTPSValidation();
+
+        createUserIfNotExists(HRS_TESTER, HRS_TESTER_ROLES);
+        createUserIfNotExists(USER_WITH_SEARCHER_ROLE__CASEWORKER_HRS, CASE_WORKER_HRS_ROLE);
+        createUserIfNotExists(USER_WITH_REQUESTOR_ROLE__CASEWORKER, CASE_WORKER_ROLE);
+        createUserIfNotExists(USER_WITH_NONACCESS_ROLE__CITIZEN, CITIZEN_ROLE);
+
         idamAuth_hrs_tester = idamHelper.authenticateUser(HRS_TESTER);
         s2sAuth = BEARER + s2sHelper.getS2sToken();
         userId_hrs_tester = idamHelper.getUserId(HRS_TESTER);
 
-        idamHelper.createUser(USER_WITH_SEARCHER_ROLE__CASEWORKER_HRS, CASE_WORKER_HRS_ROLE);
-        idamHelper.createUser(USER_WITH_REQUESTOR_ROLE__CASEWORKER, CASE_WORKER_ROLE);
-        idamHelper.createUser(USER_WITH_NONACCESS_ROLE__CITIZEN, CITIZEN_ROLE);
 
+    }
 
+    private void createUserIfNotExists(String email, List<String> roles) {
+        /* in some cases, there were conflicts between PR branches being built
+        due to users being deleted / recreated
+
+        as the roles are static they do not need to be deleted each time
+        should the roles change for users, then the recreateUsers flag will need to be true before merging to master
+         */
+
+        boolean recreateUsers = false;
+
+        if (recreateUsers) {
+            idamHelper.createUser(email, roles);
+        } else {
+            try {
+                idamHelper.getUserId(email);
+            } catch (Exception e) {//if user does not exist
+                idamHelper.createUser(email, roles);
+            }
+        }
     }
 
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
@@ -80,7 +80,7 @@ public abstract class BaseTest {
     protected static final String TIME = "2020-11-04-14.56.32.819";
     public static final String CASEREF_PREFIX = "FUNCTEST_";
     protected static List<String> CASE_WORKER_ROLE = List.of("caseworker");
-    protected static List<String> CASE_WORKER_HRS_ROLE = List.of("caseworker-hrs");
+    protected static List<String> CASE_WORKER_HRS_ROLE = List.of("caseworker","caseworker-hrs");
     protected static List<String> CITIZEN_ROLE = List.of("citizen");
     protected static final String CLOSE_CASE = "closeCase";
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
@@ -48,7 +48,6 @@ import javax.annotation.PostConstruct;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static uk.gov.hmcts.reform.em.hrs.testutil.ExtendedCcdHelper.HRS_TESTER;
 
 @SpringBootTest(classes = {
     ExtendedCcdHelper.class,
@@ -75,12 +74,11 @@ public abstract class BaseTest {
     protected static final String USER_WITH_REQUESTOR_ROLE__CASEWORKER = "em-test-caseworker@test.email";
     protected static final String USER_WITH_NONACCESS_ROLE__CITIZEN = "em-test-citizen@test.email";
     protected static final String EMAIL_ADDRESS_INVALID_FORMAT = "invalid@emailaddress";
-    protected static final int SEGMENT = 0;
     protected static final String FOLDER = "audiostream123455";
     protected static final String TIME = "2020-11-04-14.56.32.819";
     public static final String CASEREF_PREFIX = "FUNCTEST_";
     protected static List<String> CASE_WORKER_ROLE = List.of("caseworker");
-    protected static List<String> CASE_WORKER_HRS_ROLE = List.of("caseworker","caseworker-hrs");
+    protected static List<String> CASE_WORKER_HRS_ROLE = List.of("caseworker", "caseworker-hrs");
     protected static List<String> CITIZEN_ROLE = List.of("citizen");
     protected static final String CLOSE_CASE = "closeCase";
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
@@ -144,7 +144,7 @@ public abstract class BaseTest {
         should the roles change for users, then the recreateUsers flag will need to be true before merging to master
          */
 
-        boolean recreateUsers = false;
+        boolean recreateUsers = true;
 
         if (recreateUsers) {
             idamHelper.createUser(email, roles);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
@@ -124,10 +124,10 @@ public abstract class BaseTest {
     public void init() {
         SerenityRest.useRelaxedHTTPSValidation();
 
-        createUserIfNotExists(HRS_TESTER, HRS_TESTER_ROLES);
-        createUserIfNotExists(USER_WITH_SEARCHER_ROLE__CASEWORKER_HRS, CASE_WORKER_HRS_ROLE);
-        createUserIfNotExists(USER_WITH_REQUESTOR_ROLE__CASEWORKER, CASE_WORKER_ROLE);
-        createUserIfNotExists(USER_WITH_NONACCESS_ROLE__CITIZEN, CITIZEN_ROLE);
+//        createUserIfNotExists(HRS_TESTER, HRS_TESTER_ROLES);
+//        createUserIfNotExists(USER_WITH_SEARCHER_ROLE__CASEWORKER_HRS, CASE_WORKER_HRS_ROLE);
+//        createUserIfNotExists(USER_WITH_REQUESTOR_ROLE__CASEWORKER, CASE_WORKER_ROLE);
+//        createUserIfNotExists(USER_WITH_NONACCESS_ROLE__CITIZEN, CITIZEN_ROLE);
 
         idamAuth_hrs_tester = idamHelper.authenticateUser(HRS_TESTER);
         s2sAuth = BEARER + s2sHelper.getS2sToken();

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
@@ -124,10 +124,10 @@ public abstract class BaseTest {
     public void init() {
         SerenityRest.useRelaxedHTTPSValidation();
 
-//        createUserIfNotExists(HRS_TESTER, HRS_TESTER_ROLES);
-//        createUserIfNotExists(USER_WITH_SEARCHER_ROLE__CASEWORKER_HRS, CASE_WORKER_HRS_ROLE);
-//        createUserIfNotExists(USER_WITH_REQUESTOR_ROLE__CASEWORKER, CASE_WORKER_ROLE);
-//        createUserIfNotExists(USER_WITH_NONACCESS_ROLE__CITIZEN, CITIZEN_ROLE);
+        createUserIfNotExists(HRS_TESTER, HRS_TESTER_ROLES);
+        createUserIfNotExists(USER_WITH_SEARCHER_ROLE__CASEWORKER_HRS, CASE_WORKER_HRS_ROLE);
+        createUserIfNotExists(USER_WITH_REQUESTOR_ROLE__CASEWORKER, CASE_WORKER_ROLE);
+        createUserIfNotExists(USER_WITH_NONACCESS_ROLE__CITIZEN, CITIZEN_ROLE);
 
         idamAuth_hrs_tester = idamHelper.authenticateUser(HRS_TESTER);
         s2sAuth = BEARER + s2sHelper.getS2sToken();
@@ -144,7 +144,7 @@ public abstract class BaseTest {
         should the roles change for users, then the recreateUsers flag will need to be true before merging to master
          */
 
-        boolean recreateUsers = true;
+        boolean recreateUsers = false;
 
         if (recreateUsers) {
             idamHelper.createUser(email, roles);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/testutil/ExtendedCcdHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/testutil/ExtendedCcdHelper.java
@@ -13,8 +13,9 @@ import uk.gov.hmcts.reform.em.test.idam.IdamHelper;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
 import javax.annotation.PostConstruct;
+
+import static uk.gov.hmcts.reform.em.hrs.BaseTest.HRS_TESTER;
 
 @Service
 public class ExtendedCcdHelper {
@@ -36,12 +37,9 @@ public class ExtendedCcdHelper {
     protected String ccdDefinitionFile;
 
 
-    public static String HRS_TESTER = "hrs.test.user@hmcts.net";
-    public static List<String> HRS_TESTER_ROLES = List.of("caseworker", "caseworker-hrs", "ccd-import");
-
     @PostConstruct
     public void init() throws Exception {
-        idamHelper.createUser(HRS_TESTER, HRS_TESTER_ROLES);
+
         importDefinitionFile();
     }
 
@@ -58,10 +56,12 @@ public class ExtendedCcdHelper {
             "x",
             "x",
             "application/octet-stream",
-            getHrsDefinitionFile());
+            getHrsDefinitionFile()
+        );
 
         ccdDefImportApi.importCaseDefinition(idamHelper.authenticateUser(HRS_TESTER),
-                                             ccdAuthTokenGenerator.generate(), multipartFile);
+                                             ccdAuthTokenGenerator.generate(), multipartFile
+        );
     }
 
     private InputStream getHrsDefinitionFile() {
@@ -70,6 +70,7 @@ public class ExtendedCcdHelper {
 
     private void createUserRole(String userRole) {
         ccdDefUserRoleApi.createUserRole(new CcdDefUserRoleApi.CreateUserRoleBody(userRole, "PUBLIC"),
-                                         idamHelper.authenticateUser(HRS_TESTER), ccdAuthTokenGenerator.generate());
+                                         idamHelper.authenticateUser(HRS_TESTER), ccdAuthTokenGenerator.generate()
+        );
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-4058


### Change description ###
actual reason for pipeline failing was IDAM timeouts - however sometimes the builds fail due to users being deleted during FTs from other PR branches. This guards against that


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
