### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -314,7 +314,7 @@ def versions = [
   serenityRestAssured : '2.3.4',
   lombok             : '1.18.20',
   reformLogging      : '5.1.7',
-  log4JVersion       : "2.16.0",
+  log4JVersion       : "2.17.0",
   springfoxSwagger   : '2.9.2',
   postgresql         : '42.2.20',
   pact_version       : '3.6.15',


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105
