### PR TITLE
experimentally disable user recreation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -389,16 +389,12 @@ dependencies {
   implementation group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.7.5'
 
 //hmcts logging
-// implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: versions.log4JVersion
-// implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4JVersion
 // no log4j impl needed if over slf4 used
   implementation group: 'org.slf4j', name: 'log4j-over-slf4j', version: '1.7.32'
   implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
   implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
   implementation group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: versions.reformLogging
 
-//hmcts resilience
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.10.RELEASE'
 
 //gov notify email service
   implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.17.2-RELEASE'

--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
@@ -136,6 +136,10 @@ public abstract class BaseTest {
 
     @PostConstruct
     public void init() {
+        int maxRuns = 1;
+
+        if (createUsersBaseTestRunCount < maxRuns) {
+
         LOGGER.info("BASE TEST POST CONSTRUCT INITIALISATIONS....");
         SerenityRest.useRelaxedHTTPSValidation();
 
@@ -168,20 +172,27 @@ public abstract class BaseTest {
         hrsSystemIdamUserId = idamHelper.getUserId(HRS_SYSTEM_IDAM_USER);
 
         createUsersBaseTestRunCount++;
+
+        }
+
     }
 
     private void createIDAMUserIfNotExists(String email, List<String> roles) {
-        /* in some cases, there were conflicts between PR branches being built
-        due to users being deleted / recreated
+        /*
 
-        as the roles are static they do not need to be deleted each time
-        should the roles change for users, then the recreateUsers flag will need to be true before merging to master
+        TODO unknown if the tests should attempt to delete & recreate users or not
+
+        if multiple PR branches are triggered, then it means the user token cache used by em-test-helper
+        will become stale
+
+        potential for conflict with hrs-api using the hrs.tester@hmcts.net system user
+        probably these tests should not use that user, however many issues arose when
+        trying to refactor this logic and there was not enough time to see it through.
+
          */
 
-        boolean recreateUsers = true;
-        int maxRuns = 1;
+        boolean recreateUsers = false;
 
-        if (createUsersBaseTestRunCount < maxRuns) {
             if (recreateUsers) {
                 LOGGER.info("CREATING USER {} with roles {}", email, roles);
                 idamHelper.createUser(email, roles);
@@ -195,11 +206,6 @@ public abstract class BaseTest {
                 }
             }
 
-
-        } else {
-            LOGGER.info("create user count {} >= maxruns {}", createUsersBaseTestRunCount, maxRuns);
-
-        }
     }
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-4233

### Change description ###
Experiment to see if not recreating users will work in order to avoid conflicts of iadm auth token caching


**Does this PR introduce a breaking change?** (check one with "x")

```
dont know
```
