### PR TITLE
stop ccd def upload and idam role creation in functional tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/em/hrs/BaseTest.java
@@ -37,7 +37,6 @@ import uk.gov.hmcts.reform.em.test.retry.RetryRule;
 import uk.gov.hmcts.reform.em.test.s2s.S2sHelper;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 
-import java.io.IOException;
 import java.security.SecureRandom;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -77,11 +76,6 @@ public abstract class BaseTest {
     public static String SYSTEM_USER_FOR_FUNCTIONAL_TEST_ORCHESTRATION =
         "hrs.functional.system.user@hmcts.net";
 
-    public static List<String>
-        SYSTEM_USER_FOR_FUNCTIONAL_TEST_ORCHESTRATION_ROLES =
-        List.of("caseworker", "caseworker-hrs", "caseworker-hrs-searcher", "ccd-import");
-
-
     protected static final String USER_WITH_SEARCHER_ROLE__CASEWORKER_HRS = "em-test-searcher@test.hmcts.net";
     protected static final String USER_WITH_REQUESTOR_ROLE__CASEWORKER_ONLY = "em-test-requestor@test.hmcts.net";
     protected static final String USER_WITH_NONACCESS_ROLE__CITIZEN = "em-test-citizen@test.hmcts.net";
@@ -91,15 +85,9 @@ public abstract class BaseTest {
     protected static final String FOLDER = "audiostream123455";
     protected static final String TIME = "2020-11-04-14.56.32.819";
     public static final String CASEREF_PREFIX = "FUNCTEST_";
-    protected static List<String> CASE_WORKER_ROLE = List.of("caseworker");
-    protected static List<String> CASE_WORKER_HRS_SEARCHER_ROLE =
-        List.of("caseworker", "caseworker-hrs", "caseworker-hrs-searcher");
-    protected static List<String> CITIZEN_ROLE = List.of("citizen");
     protected static final String CLOSE_CASE = "closeCase";
 
     protected static int FIND_CASE_TIMEOUT = 30;
-
-    static int createUsersBaseTestRunCount = 0;
 
     protected String hrsS2sAuth;
 
@@ -135,37 +123,6 @@ public abstract class BaseTest {
 
     @PostConstruct
     public void init() {
-        int maxRuns = 1;
-
-        if (createUsersBaseTestRunCount < maxRuns) {
-
-            LOGGER.info("BASE TEST POST CONSTRUCT INITIALISATIONS....");
-            SerenityRest.useRelaxedHTTPSValidation();
-
-
-            LOGGER.info("CREATING HRS FUNCTIONAL TEST SYSTEM USER");
-            createIdamUserIfNotExists(
-                SYSTEM_USER_FOR_FUNCTIONAL_TEST_ORCHESTRATION,
-                SYSTEM_USER_FOR_FUNCTIONAL_TEST_ORCHESTRATION_ROLES
-            );
-
-            LOGGER.info("CREATING REGULAR TEST USERS");
-
-            createIdamUserIfNotExists(USER_WITH_SEARCHER_ROLE__CASEWORKER_HRS, CASE_WORKER_HRS_SEARCHER_ROLE);
-            createIdamUserIfNotExists(USER_WITH_REQUESTOR_ROLE__CASEWORKER_ONLY, CASE_WORKER_ROLE);
-            createIdamUserIfNotExists(USER_WITH_NONACCESS_ROLE__CITIZEN, CITIZEN_ROLE);
-
-            LOGGER.info("IMPORTING CCD DEFINITION");
-
-            try {
-                extendedCcdHelper.importDefinitionFile();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-
-            createUsersBaseTestRunCount++;
-
-        }
         LOGGER.info("AUTHENTICATING TEST USER FOR CCD CALLS");
         hrsS2sAuth = BEARER + s2sHelper.getS2sToken();
     }


### PR DESCRIPTION

### Change description ###

stop ccd def upload and idam role creation in functional tests

master pipeline is broken with 

`22:19:13  FolderScenarios STANDARD_OUT
22:19:13      2022-02-14T22:19:13.169 ERROR [Test worker] o.springframework.test.context.TestContextManagerorg.springframework.beans.factory.BeanCreationException: Error creating bean with name 'uk.gov.hmcts.reform.em.hrs.FolderScenarios.ORIGINAL': Invocation of init method failed; nested exception is org.springframework.web.client.HttpClientErrorException$Forbidden: 403 Forbidden: [no body]
22:19:13      	at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.postProcessBeforeInitialization(InitDestroyAnnotationBeanPostProcessor.java:160)
22:19:13      	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:415)
22:19:13      	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1791)
22:19:13      	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:406)
22:19:13      	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.injectDependencies(DependencyInjectionTestExecutionListener.java:120)
22:19:13      	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.prepareTestInstance(DependencyInjectionTestExecutionListener.java:83)
22:19:13      	at org.springframework.boot.test.autoconfigure.SpringBootDependencyInjectionTestExecutionListener.prepareTestInstance(SpringBootDependencyInjectionTestExecutionListener.java:43)
22:19:13      	at org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:244)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.createTest(SpringJUnit4ClassRunner.java:227)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner$1.runReflectiveCall(SpringJUnit4ClassRunner.java:289)
22:19:13      	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.methodBlock(SpringJUnit4ClassRunner.java:291)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:246)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:97)
22:19:13      	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
22:19:13      	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
22:19:13      	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
22:19:13      	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
22:19:13      	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
22:19:13      	at org.springframework.test.context.junit4.statements.RunBeforeTestClassCallbacks.evaluate(RunBeforeTestClassCallbacks.java:61)
22:19:13      	at org.springframework.test.context.junit4.statements.RunAfterTestClassCallbacks.evaluate(RunAfterTestClassCallbacks.java:70)
22:19:13      	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
22:19:13      	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.run(SpringJUnit4ClassRunner.java:190)
22:19:13      	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
22:19:13      	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
22:19:13      	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:43)
22:19:13      	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
22:19:13      	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
22:19:13      	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
22:19:13      	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
22:19:13      	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
22:19:13      	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
22:19:13      	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
22:19:13      	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
22:19:13      	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
22:19:13      	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
22:19:13      	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:82)
22:19:13      	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:73)
22:19:13      	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:108)
22:19:13      	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
22:19:13      	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
22:19:13      	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
22:19:13      	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
22:19:13      	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:96)
22:19:13      	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:75)
22:19:13      	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
22:19:13      	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
22:19:13      	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
22:19:13      	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
22:19:13      Caused by: org.springframework.web.client.HttpClientErrorException$Forbidden: 403 Forbidden: [no body]
22:19:13      	at org.springframework.web.client.HttpClientErrorException.create(HttpClientErrorException.java:109)
22:19:13      	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:184)
22:19:13      	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:125)
22:19:13      	at org.springframework.web.client.ResponseErrorHandler.handleError(ResponseErrorHandler.java:63)
22:19:13      	at org.springframework.web.client.RestTemplate.handleResponse(RestTemplate.java:780)
22:19:13      	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:738)
22:19:13      	at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:672)
22:19:13      	at org.springframework.web.client.RestTemplate.postForObject(RestTemplate.java:416)
22:19:13      	at uk.gov.hmcts.reform.em.test.ccddefinition.CcdDefImportApi.importCaseDefinition(CcdDefImportApi.java:45)
22:19:13      	at uk.gov.hmcts.reform.em.hrs.testutil.ExtendedCcdHelper.importDefinitionFile(ExtendedCcdHelper.java:61)
22:19:13      	at uk.gov.hmcts.reform.em.hrs.BaseTest.init(BaseTest.java:161)
22:19:13      	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
22:19:13      	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
22:19:13      	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
22:19:13      	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
22:19:13      	at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor$LifecycleElement.invoke(InitDestroyAnnotationBeanPostProcessor.java:389)
22:19:13      	at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor$LifecycleMetadata.invokeInitMethods(InitDestroyAnnotationBeanPostProcessor.java:333)
22:19:13      	at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.postProcessBeforeInitialization(InitDestroyAnnotationBeanPostProcessor.java:157)
22:19:13      	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:415)
22:19:13      	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1791)
22:19:13      	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:406)
22:19:13      	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.injectDependencies(DependencyInjectionTestExecutionListener.java:120)
22:19:13      	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.prepareTestInstance(DependencyInjectionTestExecutionListener.java:83)
22:19:13      	at org.springframework.boot.test.autoconfigure.SpringBootDependencyInjectionTestExecutionListener.prepareTestInstance(SpringBootDependencyInjectionTestExecutionListener.java:43)
22:19:13      	at org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:244)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.createTest(SpringJUnit4ClassRunner.java:227)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner$1.runReflectiveCall(SpringJUnit4ClassRunner.java:289)
22:19:13      	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.methodBlock(SpringJUnit4ClassRunner.java:291)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:246)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:97)
22:19:13      	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
22:19:13      	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
22:19:13      	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
22:19:13      	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
22:19:13      	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
22:19:13      	at org.springframework.test.context.junit4.statements.RunBeforeTestClassCallbacks.evaluate(RunBeforeTestClassCallbacks.java:61)
22:19:13      	at org.springframework.test.context.junit4.statements.RunAfterTestClassCallbacks.evaluate(RunAfterTestClassCallbacks.java:70)
22:19:13      	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
22:19:13      	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
22:19:13      	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.run(SpringJUnit4ClassRunner.java:190)
22:19:13      	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
22:19:13      	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
22:19:13      	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:43)
22:19:13      	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
22:19:13      	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
22:19:13      	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
22:19:13      	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
22:19:13      	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
22:19:13      	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
22:19:13       Caught exception while allowing TestExecutionListener [org.springframework.boot.test.autoconfigure.SpringBootDependencyInjectionTestExecutionListener@352bea0e] to prepare test instance [uk.gov.hmcts.reform.em.hrs.FolderScenarios@58cebce6]
22:19:13  `

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
