### PR TITLE
EM-4278 use now for createon field

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/hrs/service/PermissionEvaluatorImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/hrs/service/PermissionEvaluatorImpl.java
@@ -84,7 +84,7 @@ public class PermissionEvaluatorImpl implements PermissionEvaluator {
             );
             List<HearingRecordingSharee> sharedRecordings = shareesRepository.findByShareeEmailIgnoreCase(shareeEmail);
             LOGGER.info(
-                "recordings that are shared with the user: ({})",
+                "recordings that are shared with the user: ({}) are ({})", shareeEmail,
                 sharedRecordings.stream()
                     .map(sharedRecording -> sharedRecording.getHearingRecording().getCaseRef())
                     .collect(Collectors.toList())
@@ -98,11 +98,6 @@ public class PermissionEvaluatorImpl implements PermissionEvaluator {
                     return true;
                 }
             }
-            LOGGER.info(
-                "Number of recordings found while User attempted to access recording ref ({}) with email ({}) is ({})",
-                hr.getRecordingRef(),
-                shareeEmail, sharedRecordings.size()
-            );
             auditEntryService.createAndSaveEntry(hrSegment, AuditActions.USER_DOWNLOAD_UNAUTHORIZED);
         }
         return false;//Not a segment

--- a/src/main/java/uk/gov/hmcts/reform/em/hrs/service/PermissionEvaluatorImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/hrs/service/PermissionEvaluatorImpl.java
@@ -98,6 +98,11 @@ public class PermissionEvaluatorImpl implements PermissionEvaluator {
                     return true;
                 }
             }
+            LOGGER.info(
+                "Number of recordings found while User attempted to access recording ref ({}) with email ({}) is ({})",
+                hr.getRecordingRef(),
+                shareeEmail, sharedRecordings.size()
+            );
             auditEntryService.createAndSaveEntry(hrSegment, AuditActions.USER_DOWNLOAD_UNAUTHORIZED);
         }
         return false;//Not a segment

--- a/src/main/java/uk/gov/hmcts/reform/em/hrs/service/ccd/CcdUploadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/hrs/service/ccd/CcdUploadServiceImpl.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.em.hrs.repository.HearingRecordingRepository;
 import uk.gov.hmcts.reform.em.hrs.repository.HearingRecordingSegmentRepository;
 import uk.gov.hmcts.reform.em.hrs.service.FolderService;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -107,7 +108,7 @@ public class CcdUploadServiceImpl implements CcdUploadService {
             .hearingSource(recordingDto.getRecordingSource())
             .jurisdictionCode(recordingDto.getJurisdictionCode())
             .serviceCode(recordingDto.getServiceCode())
-            .createdOn(recordingDto.getRecordingDateTime())
+            .createdOn(LocalDateTime.now())
             .build();
 
         try {


### PR DESCRIPTION

### Change description ###

EM-4278 use now for createon field.
HearingRecording may have many segments, we can not add segment's recording date as createOn date for HearingRecording. If we want recornding date data we need to add this to segment table.

This PR is just for fixing the HearingRecording table.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
