### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -313,6 +313,7 @@ dependencies {
 //hmcts logging
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: versions.reformLogging
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging-spring', version: '5.1.9'
 
 //gov notify email service
   implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '4.1.0-RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -250,7 +250,7 @@ def versions = [
   serenityreporter   : '3.7.0',
   serenityRestAssured : '3.7.0',
   lombok             : '1.18.20',
-  reformLogging      : '5.1.9',
+  reformLogging      : '6.0.1',
   log4JVersion       : "2.17.1",
   postgresql         : '42.5.1',
   pact_version       : '3.6.15',

--- a/build.gradle
+++ b/build.gradle
@@ -313,7 +313,6 @@ dependencies {
 //hmcts logging
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: versions.reformLogging
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging-spring', version: versions.reformLogging
 
 //gov notify email service
   implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '4.1.0-RELEASE'


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.