### PR TITLE
upgrading cftlib to v0.19.1262

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
   id 'org.flywaydb.flyway' version '10.14.0'
   id 'au.com.dius.pact' version '4.2.14'
   id "info.solidsoft.pitest" version '1.15.0'
-  id 'com.github.hmcts.rse-cft-lib' version '0.19.1260'
+  id 'com.github.hmcts.rse-cft-lib' version '0.19.1262'
   id 'uk.gov.hmcts.java' version '0.12.63'
   id 'org.owasp.dependencycheck' version '9.2.0'
   id 'net.serenity-bdd.serenity-gradle-plugin' version '3.0.0'


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/EM-6070

### Change description ###

Note - cftlib 0.19.1262 has a dependency within AM that requires java 17 within the toolchain to run properly.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
