### PR TITLE
EM-6254 avoid using connection  key

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -112,14 +112,14 @@ azure:
     instrumentation-key: ${APPINSIGHTS_INSTRUMENTATIONKEY:dummy}
   storage:
     hrs:
-      connection-string: ${STORAGEACCOUNT_PRIMARY_CONNECTION_STRING:DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1}
+      connection-string: ${STORAGEACCOUNT_PRIMARY_CONNECTION_STRING:UseDevelopmentStorage=true}
       cvp-dest-blob-container-name: ${HRS_CVP_DEST_CONTAINER_NAME:emhrstestcontainer}
       vh-dest-blob-container-name: ${HRS_VH_DEST_CONTAINER_NAME:emhrsvhtestcontainer}
     cvp:
-      connection-string: ${CVP_STORAGE_CONNECTION_STRING:DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1}
+      connection-string: ${CVP_STORAGE_CONNECTION_STRING:UseDevelopmentStorage=true}
       blob-container-reference: ${CVP_STORAGE_CONTAINER_NAME:cvptestcontainer}
     vh:
-      connection-string: ${VH_STORAGE_CONNECTION_STRING:DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1}
+      connection-string: ${VH_STORAGE_CONNECTION_STRING:UseDevelopmentStorage=true}
       blob-container-name: ${VH_STORAGE_CONTAINER_NAME:vhtestcontainer}
     use-ad-auth: ${USE_AD_AUTH_FOR_SOURCE_BLOB_CONNECTION:false}
 


### PR DESCRIPTION
 avoid using connection  key, Fortify thinks they are real and Fortify team reject to suppress them.
<img width="1285" alt="Screenshot 2024-09-20 at 08 07 33" src="https://github.com/user-attachments/assets/c36db657-b93e-40c5-ba4b-144666f2db56">


instead of long connection key 
"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"

https://github.com/Azure/Azurite
use short connection string:

"UseDevelopmentStorage=true"