### PR TITLE
EM-6034 add ttl with date type

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/hrs/domain/HearingRecording.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/hrs/domain/HearingRecording.java
@@ -21,6 +21,7 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.UUID;
@@ -67,6 +68,7 @@ public class HearingRecording {
     private Set<HearingRecordingAuditEntry> auditEntries;
 
 
+    private LocalDate ttl;
     private String recordingRef;
     private String caseRef;
     private String hearingLocationCode;
@@ -85,6 +87,7 @@ public class HearingRecording {
                             LocalDateTime modifiedOn, LocalDateTime createdOn,
                             boolean deleted, boolean ttlSet, Folder folder,
                             Set<HearingRecordingAuditEntry> auditEntries,
+                            LocalDate ttl,
                             String recordingRef, String caseRef, String hearingLocationCode,
                             String hearingRoomRef, String hearingSource,
                             String jurisdictionCode, String serviceCode, Long ccdCaseId,
@@ -101,6 +104,7 @@ public class HearingRecording {
         setFolder(folder);
 
         setAuditEntries(auditEntries);
+        setTtl(ttl);
 
         setRecordingRef(recordingRef);
         setCaseRef(caseRef);

--- a/src/main/resources/db/migration/V9__add_column_ttl_hearing_recording.sql
+++ b/src/main/resources/db/migration/V9__add_column_ttl_hearing_recording.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hearing_recording ADD COLUMN ttl DATE;


### PR DESCRIPTION

In previous [ pr](https://github.com/hmcts/em-hrs-api/pull/2072) removed the existing empty timestamp "ttl" column
[EM-6034](https://tools.hmcts.net/jira/browse/EM-6034) adding  "ttl" backwith "date" type