### PR TITLE
add azapi to state 

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -69,7 +69,7 @@ resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
 }
 
 module "storage_account" {
-  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=5.x"
+  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=4.x"
   env                      = var.env
   storage_account_name     = "emhrsapi${var.env}"
   resource_group_name      = azurerm_resource_group.rg.name
@@ -147,7 +147,7 @@ resource "azurerm_key_vault_secret" "storage_account_secondary_connection_string
 module "cvp_storage_account_simulator" {
   count = var.env == "aat" ? 1 : 0
 
-  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=5.x"
+  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=4.x"
   env                      = var.env
   storage_account_name     = "emhrscvp${var.env}"
   resource_group_name      = azurerm_resource_group.rg.name

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -69,7 +69,7 @@ resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
 }
 
 module "storage_account" {
-  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=4.x"
+  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=5.x"
   env                      = var.env
   storage_account_name     = "emhrsapi${var.env}"
   resource_group_name      = azurerm_resource_group.rg.name
@@ -147,7 +147,7 @@ resource "azurerm_key_vault_secret" "storage_account_secondary_connection_string
 module "cvp_storage_account_simulator" {
   count = var.env == "aat" ? 1 : 0
 
-  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=4.x"
+  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=5.x"
   env                      = var.env
   storage_account_name     = "emhrscvp${var.env}"
   resource_group_name      = azurerm_resource_group.rg.name

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.5.0"
+      version = "~> 4.6.0"
 
     }
   }

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.6.0"
+      version = "~> 4.5.0"
 
     }
   }

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -11,5 +11,9 @@ terraform {
       version = "~> 4.6.0"
 
     }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 1.15.0"
+    }
   }
 }


### PR DESCRIPTION

https://tools.hmcts.net/jira/browse/DTSPO-19592

pipeline fails with
```
16:44:57  [31m│[0m [0m[0m  with module.cvp_storage_account_simulator[0].azapi_update_resource.defender_settings,
16:44:57  [31m│[0m [0m  on .terraform/modules/cvp_storage_account_simulator/defender.tf line 5, in resource "azapi_update_resource" "defender_settings":
16:44:57  [31m│[0m [0m   5:   body = [4mjsonencode({
16:44:57  [31m│[0m [0m   6:     properties = {
16:44:57  [31m│[0m [0m   7:       isEnabled = var.defender_enabled
16:44:57  [31m│[0m [0m   8:       malwareScanning = {
16:44:57  [31m│[0m [0m   9:         onUpload = {
16:44:57  [31m│[0m [0m  10:           isEnabled     = var.defender_enabled == false ? false : var.defender_malware_scanning_enabled
16:44:57  [31m│[0m [0m  11:           capGBPerMonth = var.defender_enabled == false ? -1 : var.defender_malware_scanning_cap_gb_per_month
16:44:57  [31m│[0m [0m  12:         }
16:44:57  [31m│[0m [0m  13:       }
16:44:57  [31m│[0m [0m  14:       sensitiveDataDiscovery = {
16:44:57  [31m│[0m [0m  15:         isEnabled = var.defender_enabled == false ? false : var.defender_sensitive_data_discovery_enabled
16:44:57  [31m│[0m [0m  16:       }
16:44:57  [31m│[0m [0m  17:       overrideSubscriptionLevelSettings = var.defender_override_subscription_level_settings
16:44:57  [31m│[0m [0m  18:     }
16:44:57  [31m│[0m [0m  19:   })[0m[0m
16:44:57  [31m│[0m [0m
16:44:57  [31m│[0m [0mThe value must not be a string
```
