### PR TITLE
Revert "Update Terraform azurerm to ~> 4.16.0 (#2269)"

### DIFF
--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.16.0"
+      version = "~> 4.15.0"
 
     }
     azapi = {


### PR DESCRIPTION
This reverts commit a0e2b9413a0c444c8a4c3519740fec875abca09a.
Revert "Update Terraform azurerm to ~> 4.16.0 (#2269)" as main fails with 


```
11:39:42  
11:39:42  Terraform used the selected providers to generate the following execution
11:39:42  plan. Resource actions are indicated with the following symbols:
11:39:42    [33m~[0m update in-place[0m
11:39:42  
11:39:42  Terraform planned the following actions, but then encountered a problem:
11:39:42  
11:39:42  [1m  # module.cvp_storage_account_simulator[0].azurerm_storage_account.storage_account[0m will be updated in-place
11:39:42  [0m  [33m~[0m[0m resource "azurerm_storage_account" "storage_account" {
11:39:42          id                                 = "/subscriptions/****/resourceGroups/em-hrs-api-aat/providers/Microsoft.Storage/storageAccounts/emhrscvpaat"
11:39:42          name                               = "emhrscvpaat"
11:39:42          tags                               = {
11:39:42              "application"         = "evidence-management"
11:39:42              "autoShutdown"        = "true"
11:39:42              "builtFrom"           = "https://github.com/HMCTS/em-hrs-api.git"
11:39:42              "businessArea"        = "CFT"
11:39:42              "contactSlackChannel" = "#em-dev-chat"
11:39:42              "environment"         = "staging"
11:39:42              "managedBy"           = "Evidence Management"
11:39:42          }
11:39:42          [90m# (96 unchanged attributes hidden)[0m[0m
11:39:42  
11:39:42        [32m+[0m[0m network_rules {
11:39:42            [32m+[0m[0m bypass         = [
11:39:42                [32m+[0m[0m "AzureServices",
11:39:42              ]
11:39:42            [32m+[0m[0m default_action = "Allow"
11:39:42          }
11:39:42  
11:39:42          [90m# (3 unchanged blocks hidden)[0m[0m
11:39:42      }
11:39:42  
11:39:42  [1m  # module.storage_account.azurerm_storage_account.storage_account[0m will be updated in-place
11:39:42  [0m  [33m~[0m[0m resource "azurerm_storage_account" "storage_account" {
11:39:42          id                                 = "/subscriptions/****/resourceGroups/em-hrs-api-aat/providers/Microsoft.Storage/storageAccounts/emhrsapiaat"
11:39:42          name                               = "emhrsapiaat"
11:39:42          tags                               = {
11:39:42              "application"         = "evidence-management"
11:39:42              "autoShutdown"        = "true"
11:39:42              "builtFrom"           = "https://github.com/HMCTS/em-hrs-api.git"
11:39:42              "businessArea"        = "CFT"
11:39:42              "contactSlackChannel" = "#em-dev-chat"
11:39:42              "environment"         = "staging"
11:39:42              "managedBy"           = "Evidence Management"
11:39:42          }
11:39:42          [90m# (96 unchanged attributes hidden)[0m[0m
11:39:42  
11:39:42        [32m+[0m[0m network_rules {
11:39:42            [32m+[0m[0m bypass         = [
11:39:42                [32m+[0m[0m "AzureServices",
11:39:42              ]
11:39:42            [32m+[0m[0m default_action = "Allow"
11:39:42          }
11:39:42  
11:39:42          [90m# (3 unchanged blocks hidden)[0m[0m
11:39:42      }
11:39:42  
11:39:42  [1mPlan:[0m 0 to add, 2 to change, 0 to destroy.
11:39:42  [0m[33m╷[0m[0m
11:39:42  [33m│[0m [0m[1m[33mWarning: [0m[0m[1mArgument is deprecated[0m
11:39:42  [33m│[0m [0m
11:39:42  [33m│[0m [0m[0m  with provider["registry.terraform.io/hashicorp/azurerm"].cft_vnet,
11:39:42  [33m│[0m [0m  on main.tf line 8, in provider "azurerm":
11:39:42  [33m│[0m [0m   8:   skip_provider_registration = [4mtrue[0m[0m
11:39:42  [33m│[0m [0m
11:39:42  [33m│[0m [0mThis property is deprecated and will be removed in v5.0 of the AzureRM
11:39:42  [33m│[0m [0mprovider. Please use the `resource_provider_registrations` property
11:39:42  [33m│[0m [0minstead.
11:39:42  [33m│[0m [0m
11:39:42  [33m│[0m [0m(and 5 more similar warnings elsewhere)
11:39:42  [33m╵[0m[0m
11:39:42  [33m╷[0m[0m
11:39:42  [33m│[0m [0m[1m[33mWarning: [0m[0m[1mAttribute Deprecated[0m
11:39:42  [33m│[0m [0m
11:39:42  [33m│[0m [0m[0m  with provider["registry.terraform.io/hashicorp/azurerm"].cft_vnet,
11:39:42  [33m│[0m [0m  on main.tf line 8, in provider "azurerm":
11:39:42  [33m│[0m [0m   8:   skip_provider_registration = [4mtrue[0m[0m
11:39:42  [33m│[0m [0m
11:39:42  [33m│[0m [0mThis property is deprecated and will be removed in v5.0 of the AzureRM
11:39:42  [33m│[0m [0mprovider. Please use the `resource_provider_registrations` property
11:39:42  [33m│[0m [0minstead.
11:39:42  [33m│[0m [0m
11:39:42  [33m│[0m [0m(and one more similar warning elsewhere)
11:39:42  [33m╵[0m[0m
11:39:42  [31m╷[0m[0m
11:39:42  [31m│[0m [0m[1m[31mError: [0m[0m[1mretrieving Flexible Server (Subscription: "****"
11:39:42  [31m│[0m [0mResource Group Name: "em-hrs-api-postgres-db-v15-data-aat"
11:39:42  [31m│[0m [0mFlexible Server Name: "em-hrs-api-postgres-db-v15-aat"): Get "https://management.azure.com/subscriptions/****/resourceGroups/em-hrs-api-postgres-db-v15-data-aat/providers/Microsoft.DBforPostgreSQL/flexibleServers/em-hrs-api-postgres-db-v15-aat?api-version=2023-06-01-preview": context deadline exceeded[0m
11:39:42  [31m│[0m [0m
11:39:42  [31m│[0m [0m[0m  with module.db-v15.azurerm_postgresql_flexible_server.pgsql_server,
11:39:42  [31m│[0m [0m  on .terraform/modules/db-v15/pgsql-flexible-server.tf line 71, in resource "azurerm_postgresql_flexible_server" "pgsql_server":
11:39:42  [31m│[0m [0m  71: resource "azurerm_postgresql_flexible_server" "pgsql_server" [4m{[0m[0m
11:39:42  [31m│[0m [0m
11:39:42  [31m╵[0m[0m
11:39:42  [Pipeline] }
11:39:42  [Pipeline] // stage
11:39:42  [Pipeline] }
11:39:42  Lock released on resource [Resource: em-hrs-api-aat]
```
