### PR TITLE
EM-6614-remove-extension

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -253,7 +253,7 @@ module "db-v15" {
   pgsql_server_configuration = [
     {
       name  = "azure.extensions"
-      value = "plpgsql,pg_stat_statements,pg_buffercache,uuid-ossp"
+      value = "pg_stat_statements,pg_buffercache,uuid-ossp"
     }
   ]
   //Below attributes needs to be overridden for Perftest & Prod


### PR DESCRIPTION
[EM-6614](https://tools.hmcts.net/jira/browse/EM-6614)  remove-extension
main fails with 
```
16:47:33  [33m│[0m [0m[0m  with provider["registry.terraform.io/hashicorp/azurerm"].cft_vnet,
16:47:33  [33m│[0m [0m  on main.tf line 8, in provider "azurerm":
16:47:33  [33m│[0m [0m   8:   skip_provider_registration = [4mtrue[0m[0m
16:47:33  [33m│[0m [0m
16:47:33  [33m│[0m [0mThis property is deprecated and will be removed in v5.0 of the AzureRM
16:47:33  [33m│[0m [0mprovider. Please use the `resource_provider_registrations` property
16:47:33  [33m│[0m [0minstead.
16:47:33  [33m│[0m [0m
16:47:33  [33m│[0m [0m(and one more similar warning elsewhere)
16:47:33  [33m╵[0m[0m
16:47:33  [31m╷[0m[0m
16:47:33  [31m│[0m [0m[1m[31mError: [0m[0m[1mupdating Configuration (Subscription: "****"
16:47:33  [31m│[0m [0mResource Group Name: "em-hrs-api-postgres-db-v15-data-prod"
16:47:33  [31m│[0m [0mFlexible Server Name: "em-hrs-api-postgres-db-v15-prod"
16:47:33  [31m│[0m [0mConfiguration Name: "azure.extensions"): polling after Update: polling failed: the Azure API returned the following error:
16:47:33  [31m│[0m [0m
16:47:33  [31m│[0m [0mStatus: "ServerParameterToCMSUnAllowedParameterValue"
16:47:33  [31m│[0m [0mCode: ""
16:47:33  [31m│[0m [0mMessage: "The value: [plpgsql,pg_stat_statements,pg_buffercache,uuid-ossp] of Server Parameter: [azure.extensions] is invalid, the allowed values are: [,address_standardizer,address_standardizer_data_us,age,amcheck,anon,azure_ai,azure_local_ai,azure_storage,bloom,btree_gin,btree_gist,citext,cube,dblink,dict_int,dict_xsyn,earthdistance,fuzzystrmatch,hll,hstore,hypopg,intagg,intarray,isn,lo,login_hook,ltree,oracle_fdw,orafce,pageinspect,pg_buffercache,pg_cron,pg_diskann,pg_freespacemap,pg_hint_plan,pg_partman,pg_prewarm,pg_repack,pg_squeeze,pg_stat_statements,pg_trgm,pg_visibility,pgaudit,pgcrypto,pglogical,pgrouting,pgrowlocks,pgstattuple,plv8,postgis,postgis_raster,postgis_sfcgal,postgis_tiger_geocoder,postgis_topology,postgres_fdw,postgres_protobuf,semver,session_variable,sslinfo,tablefunc,tdigest,tds_fdw,timescaledb,topn,tsm_system_rows,tsm_system_time,unaccent,uuid-ossp,vector]"
16:47:33  [31m│[0m [0mActivity Id: ""
```
